### PR TITLE
Added very simple support for Debian.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -56,7 +56,7 @@ class nfs::server (
             }
         }
 
-        ubuntu : {
+        ubuntu, debian : {
             class { 'nfs::server::ubuntu':
                 package => $package,
                 service => $service,


### PR DESCRIPTION
The nfs::server::ubuntu class also works well for Debian 7. I reviewed all of the code and it looks like it would also work well with Debian 6.

I tested this change on two Debian 7 systems, one that runs on AMD64 and one that runs on a Raspberry Pi and it worked well.
