### PR TITLE
Support for Amazon Linux

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -34,14 +34,14 @@ class nfs::client (
 
     anchor { 'nfs::client::begin': }
 
-    case $::operatingsystem {
-        centos, redhat : {
+    case $::osfamily {
+        RedHat : {
             class { 'nfs::client::rhel':
                 ensure => $ensure,
             }
         }
 
-        debian, ubuntu : {
+        Debian : {
             class { 'nfs::client::debian':
                 ensure => $ensure,
             }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -47,8 +47,8 @@ class nfs::server (
 
     anchor { 'nfs::server::begin': }
 
-    case $::operatingsystem {
-        centos, redhat : {
+    case $::osfamily {
+        RedHat : {
             class { 'nfs::server::rhel':
                 package => $package,
                 service => $service,
@@ -56,7 +56,7 @@ class nfs::server (
             }
         }
 
-        ubuntu, debian : {
+        Debian : {
             class { 'nfs::server::ubuntu':
                 package => $package,
                 service => $service,


### PR DESCRIPTION
Switching from operatingsystem to osfamily fact for Amazon Linux
support, compatible with RHEL/CentOS but not tested on Fedora.
