### PR TITLE
Added new class nfs::exports using definitions from hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,29 @@ optionally, some `nfs::export` resources.
         clients => [ "${::network_eth0}/${netmask_eth0}" ],
     }
 
+### NFS Exports
+If you want to use hiera to define all your exports in one place. If you place these elements in one of your yaml files parsed
+
+    ---
+    nfs::exports::definitions:
+      :export_hiera_1:
+        :path:        '/tmp/export_hiera_1'
+        :options:     ['rw', 'async' ]
+        :clients:     [ 192.168.1.77 ]
+      :export_hiera_chroot: 
+        :path:        /tmp/export_hiera_chroot
+        :options:     ['ro', 'async', 'no_subtree_check', 'no_root_squash' ]
+        :clients:     [ 192.168.1.0/24 ]
+
+if will produce the following /etc/exports
+
+    # This file is configured through the nfs::server puppet module.
+    /tmp/export_hiera_1 192.168.1.77(rw,async)
+
+    /tmp/export_hiera_chroot 192.168.1.0/24(ro,async,no_subtree_check,no_root_squash)
+
+Or as shown in the file `tests/exports.pp` you may enter a hash directly into your puppet file
+
 ##Reference
 _TODO_ List all the classes and organization
 

--- a/manifests/exports.pp
+++ b/manifests/exports.pp
@@ -1,0 +1,28 @@
+define one_export( 
+  $path = '',
+  $options = [],
+  $clients = [],
+        ) {
+  
+  if (!defined(File["$path"])) {
+    file{"$path": ensure => directory}
+  }
+
+  nfs::export { $path:
+      options => $options,
+      clients => $clients,
+      require => File[$path],
+  }  
+}
+
+class nfs::exports ( $definitions = {}) {
+
+  if ($puppetversion =~ /^[12]/) {
+    notify{"Your puppet version $puppetversion is too old to use nfs::exports. Required is puppet >= 3.0": }
+  }
+  else {
+    include nfs::server
+    create_resources(one_export, $definitions, {})
+  } 
+}
+

--- a/tests/exports.pp
+++ b/tests/exports.pp
@@ -1,0 +1,15 @@
+# testing exports given directly
+
+$test_exports =  {
+    export_1 => { path => '/tmp/export_1',
+      options => [ 'rw', 'async' ],
+      clients => [ "${::network_eth0}/${netmask_eth0}" ],
+    },
+
+    export_chroot => { path => '/tmp/export_chroot',
+      options => [ 'ro', 'async', 'no_subtree_check', 'no_root_squash' ],
+      clients => [ "192.168.1.0/24" ],
+    },
+}
+
+class { 'nfs::exports': definitions => $test_exports }

--- a/tests/exports_hiera.pp
+++ b/tests/exports_hiera.pp
@@ -1,0 +1,4 @@
+# Will create NFS exports for two shared if your hiera.yaml contains
+# See the readme for more explanations
+
+include nfs::exports

--- a/tests/server.pp
+++ b/tests/server.pp
@@ -1,0 +1,1 @@
+include nfs::server


### PR DESCRIPTION
I found your NFS module useful and it worked fine  for me.

Here is a small extension which allows one to store all exports in a hiera yaml file.

Also I added some simple tests/*.pp for the different classes.

Hope you find it useful, too.
