### PR TITLE
The service rpc-statd provides locking services on RHEL7

### DIFF
--- a/manifests/server/rhel/services.pp
+++ b/manifests/server/rhel/services.pp
@@ -10,7 +10,7 @@ class nfs::server::rhel::services (
         case $::operatingsystemmajrelease {
             '7': {
                 $nfs_service = 'nfs-server'
-                $nfs_lock_service = 'nfs-lock'
+                $nfs_lock_service = 'rpc-statd'
             }
             default: {
                 $nfs_service = 'nfs'


### PR DESCRIPTION
On RHEL7 the service named nfs-lock doesn't actually exist:
$ cd /usr/lib/systemd/system
$ ls -la nfs-lock.service
lrwxrwxrwx. 1 root root 17 29 okt 11:34 nfs-lock.service -> rpc-statd.service

This causes puppet to try to start the nfs-lock service on every
puppet run even when the real service (rpc-statd) is already running.

Fixed this by using the service named rpc-statd instead of nfs-lock on RHEL7
